### PR TITLE
non-helm K8s install of CF->DD

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,0 +1,13 @@
+export CFDD_REPLICAS ?= 1
+export CFDD_IMAGE ?= 1
+export CFDD_TAG ?= 1
+export CFDD_IMAGE_PULL_POLICY ?= IfNotPresent
+export CFDD_SECRETS_NAME ?= cfdd-secrets
+export CFDD_STATS_PREFIX ?= "cloudflare-k8s-"
+export CFDD_SINCE ?= "-360"
+export CFDD_TAGS ?= ""
+
+install:
+	j2 cfdd-deployment.yaml.j2 
+	#| kubectl apply -n ${K8S_NAMESPACE} -f -
+	

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,13 +1,13 @@
 export CFDD_REPLICAS ?= 1
-export CFDD_IMAGE ?= 1
-export CFDD_TAG ?= 1
+export CFDD_IMAGE ?= mozmeao/cloudflare-datadog
+export CFDD_TAG ?= 32dd3d6539131dff444239d235ad2e79fb498bc9
 export CFDD_IMAGE_PULL_POLICY ?= IfNotPresent
 export CFDD_SECRETS_NAME ?= cfdd-secrets
-export CFDD_STATS_PREFIX ?= "cloudflare-k8s-"
+export CFDD_STATS_PREFIX ?= "cfdd"
 export CFDD_SINCE ?= "-360"
 export CFDD_TAGS ?= ""
+export K8S_NAMESPACE ?= cfdd
 
 install:
-	j2 cfdd-deployment.yaml.j2 
-	#| kubectl apply -n ${K8S_NAMESPACE} -f -
-	
+	j2 cfdd-deployment.yaml.j2 | kubectl apply -n ${K8S_NAMESPACE} -f -
+

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,11 @@
+# Cloudflare -> Datadog in K8s
+
+### Installation
+
+1. Using cfdd-secrets.yaml as a template, populate the values (base64 encoded)
+2. `kubectl create namespace cfdd`
+3. `kubectl create -f mysecrets.yaml`
+4. Look at the defaults in the Makefile, and tweak accordingly. Run `make`.
+5. Wait for a few minutes to see stats show up in Datadog
+
+

--- a/k8s/cfdd-deployment.yaml.j2
+++ b/k8s/cfdd-deployment.yaml.j2
@@ -1,0 +1,66 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cfdd
+  labels:
+    app: cfdd
+spec:
+  replicas: {{ CFDD_REPLICAS }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: cfdd
+    spec:
+      restartPolicy: Always
+      containers:
+      - name: cfdd
+        image: "{{ CFDD_IMAGE }}:{{ CFDD_TAG }}"
+        imagePullPolicy: {{ CFDD_IMAGE_PULL_POLICY }}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        env:
+          STATS_KEY_PREFIX: {{ CFDD_STATS_PREFIX }}
+          SINCE: "{{ CFDD_SINCE }}"
+          TAGS: "{{ CFDD_TAGS }}"
+        - name: DATADOG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ CFDD_SECRETS_NAME }}
+              key: DATADOG_API_KEY
+        - name: DATADOG_APP_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ CFDD_SECRETS_NAME }}
+              key: DATADOG_APP_KEY
+        - name: CF_API_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: {{ CFDD_SECRETS_NAME }}
+              key: CF_API_EMAIL
+        - name: CF_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ CFDD_SECRETS_NAME }}y
+              key: CF_API_KEY
+        - name: ZONE
+          valueFrom:
+            secretKeyRef:
+              name: {{ CFDD_SECRETS_NAME }}
+              key: ZONE
+        - name: DEAD_MANS_SNITCH_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ CFDD_SECRETS_NAME }}
+              key: DEAD_MANS_SNITCH_URL
+  
+

--- a/k8s/cfdd-deployment.yaml.j2
+++ b/k8s/cfdd-deployment.yaml.j2
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: cfdd
+  namespace: cfdd
   labels:
     app: cfdd
 spec:
@@ -29,9 +30,12 @@ spec:
             cpu: 100m
             memory: 128Mi
         env:
-          STATS_KEY_PREFIX: {{ CFDD_STATS_PREFIX }}
-          SINCE: "{{ CFDD_SINCE }}"
-          TAGS: "{{ CFDD_TAGS }}"
+        - name: STATS_KEY_PREFIX
+          value: {{ CFDD_STATS_PREFIX }}
+        - name: SINCE
+          value: {{ CFDD_SINCE }}
+        - name: TAGS
+          value: {{ CFDD_TAGS }}
         - name: DATADOG_API_KEY
           valueFrom:
             secretKeyRef:
@@ -50,7 +54,7 @@ spec:
         - name: CF_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ CFDD_SECRETS_NAME }}y
+              name: {{ CFDD_SECRETS_NAME }}
               key: CF_API_KEY
         - name: ZONE
           valueFrom:

--- a/k8s/cfdd-secrets.yaml
+++ b/k8s/cfdd-secrets.yaml
@@ -12,3 +12,4 @@ data:
   CF_API_KEY:
   ZONE:
   DEAD_MANS_SNITCH_URL:
+

--- a/k8s/cfdd-secrets.yaml.j2
+++ b/k8s/cfdd-secrets.yaml.j2
@@ -6,9 +6,9 @@ metadata:
     app: cfdd
 type: Opaque
 data:
-  datadog-api-key:
-  datadog-app-key:
-  auth-email:
-  auth-key:
-  zone:
-  dead-mans_snitch-url: ""
+  DATADOG_API_KEY:
+  DATADOG_APP_KEY:
+  CF_API_EMAIL:
+  CF_API_KEY:
+  ZONE:
+  DEAD_MANS_SNITCH_URL:

--- a/k8s/cfdd-secrets.yaml.j2
+++ b/k8s/cfdd-secrets.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cfdd-secrets
+  labels:
+    app: cfdd
+type: Opaque
+data:
+  datadog-api-key:
+  datadog-app-key:
+  auth-email:
+  auth-key:
+  zone:
+  dead-mans_snitch-url: ""


### PR DESCRIPTION
prod is currently configured with a prefix of `cfdd` which you can see in Datadog. Let me know if you'd like this changed. This is part of the Deis 1 decom.